### PR TITLE
disable stp by default

### DIFF
--- a/ovsdb.go
+++ b/ovsdb.go
@@ -74,7 +74,7 @@ func NewOvsDriver(bridgeName string, ipAddr string, port int) *OvsDriver {
 	ovsDriver.ovsClient = ovs
 	ovsDriver.OvsBridgeName = bridgeName
 	ovsDriver.failMode = "standalone"
-	ovsDriver.stpEnable = true
+	ovsDriver.stpEnable = false
 	ovsDriver.ovsdbCache = make(map[string]map[string]libovsdb.Row)
 
 	go func() {
@@ -117,7 +117,7 @@ func NewOvsDriverWithUnix(bridgeName string) *OvsDriver {
 	ovsDriver.ovsClient = ovs
 	ovsDriver.OvsBridgeName = bridgeName
 	ovsDriver.failMode = "standalone"
-	ovsDriver.stpEnable = true
+	ovsDriver.stpEnable = false
 	ovsDriver.ovsdbCache = make(map[string]map[string]libovsdb.Row)
 
 	go func() {


### PR DESCRIPTION
If we set the stp enable by default, it will block all packet which sent to ovs bridge itself.
No matter what we config the ovs bridge later, clean config, stp mode, the problem still exist.
I think we can disable the stp by default and figure out what happen later.